### PR TITLE
Fixed user list batch update and batch delete limits to work with AniList limits

### DIFF
--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -32,6 +32,11 @@ def digit_str(*, max_len: int = 255) -> type[str]:
     return Annotated[str, Field(pattern=r"^\d+$", max_length=max_len)]
 
 
+def bounded_list(item_type: type[T], *, min_len: int | None = None, max_len: int | None = None) -> type[list]:
+    # noinspection PyTypeHints
+    return Annotated[list[item_type], Field(min_length=min_len, max_length=max_len)]
+
+
 def data_response(data: dict) -> DataEnvelope[dict]:
     return DataEnvelope(data=data)
 

--- a/api/schemas/user_anime_list_schemas.py
+++ b/api/schemas/user_anime_list_schemas.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 from pydantic import BaseModel
 
-from api.schemas import NonEmptyString
+from api.schemas import NonEmptyString, bounded_list
 from constants import SortDirection, AnilistAnimeUserStatus, AnilistAnimeSeason, AnilistAnimeStatus, AnilistAnimeFormat
 from api.schemas.anime_schemas import AnimeItem, AnimeItemBase
 
@@ -82,7 +82,7 @@ class UserAnimeBatchUpdateRequestData(BaseModel):
 
 
 class UserAnimeBatchUpdateRequest(BaseModel):
-    anilist_ids: list[int]
+    anilist_ids: bounded_list(int, min_len=1, max_len=25)
     data: UserAnimeBatchUpdateRequestData
 
 
@@ -91,4 +91,4 @@ class UserAnimeBatchUpdateResponse(BaseModel):
 
 
 class UserAnimeBatchDeleteRequest(BaseModel):
-    anilist_ids: list[int]
+    anilist_ids: bounded_list(int, min_len=1, max_len=50)

--- a/components/api_components/anime_api_component.py
+++ b/components/api_components/anime_api_component.py
@@ -242,6 +242,7 @@ class AnimeAPIComponent(BaseComponent):
             ],
         )
 
+    @api_component
     async def get_anime_titles(self, anilist_id: int, force_freshness: bool) -> AnimeTitlesResponse:
         anime = await self._anilist_component.get_anime(anilist_anime_id=anilist_id, force_refresh=force_freshness)
         if not anime:

--- a/components/api_components/torrent_api_component.py
+++ b/components/api_components/torrent_api_component.py
@@ -327,6 +327,7 @@ class TorrentAPIComponent(BaseComponent):
             anilist_episode_part_ceiling=body.episode_part_ceiling
         )
 
+    @api_component
     async def override_torrent(self, torrent_id: int, body: TorrentOverrideRequest) -> TorrentOverrideResponse:
         torrent_repo = TorrentRepo(get_session())
         parent_torrent = await torrent_repo.get_torrent(torrent_id=torrent_id, load_relations=True)

--- a/components/api_components/user_anime_list_api_component.py
+++ b/components/api_components/user_anime_list_api_component.py
@@ -288,6 +288,7 @@ class UserAnimeListAPIComponent(BaseComponent):
             )
         )
 
+    @api_component
     async def batch_update_anime_list_entries(self, body: UserAnimeBatchUpdateRequest) -> UserAnimeBatchUpdateResponse:
         list_entries = await self._anilist_list_component.update_user_list_entries(anilist_ids=body.anilist_ids,
                                                                                    status=body.data.status,
@@ -315,5 +316,6 @@ class UserAnimeListAPIComponent(BaseComponent):
         ) for list_entry in list_entries]
         return UserAnimeBatchUpdateResponse(updated_anime_list=items)
 
+    @api_component
     async def batch_delete_anime_list_entries(self, body: UserAnimeBatchDeleteRequest):
         await self._anilist_list_component.delete_user_list_entries(anilist_ids=body.anilist_ids)

--- a/tests/components/api_components/anime_api_component/test_get_anime_titles.py
+++ b/tests/components/api_components/anime_api_component/test_get_anime_titles.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from common.exceptions import AnilistNotFoundException
+from common.exceptions import NotFoundException
 from constants import MetadataSource
 
 _GET_ANIME = "components.service_components.anilist_component.AnilistComponent.get_anime"
@@ -33,7 +33,7 @@ class Case:
 
 CASES = [
     Case(id="missing anime raises not found",
-         anime=None, expected_exception=AnilistNotFoundException),
+         anime=None, expected_exception=NotFoundException),
     # all three anilist titles present, no tvdb mapping
     Case(id="all anilist titles, no tvdb mapping",
          anime=anime(), tvdb_series_id=None,

--- a/tests/components/api_components/user_anime_list_api_component/test_batch_update_anime_list_entries.py
+++ b/tests/components/api_components/user_anime_list_api_component/test_batch_update_anime_list_entries.py
@@ -28,8 +28,6 @@ CASES = [
                       dict(anime_id=2, status="COMPLETED", score=6.0, progress=12)],
          tracked=[(1, 99)],
          expected=[(1, 99), (2, None)]),
-    Case(id="no ids yields an empty response",
-         anilist_ids=[], entry_specs=[], tracked=[], expected=[]),
 ]
 
 


### PR DESCRIPTION
Addresses #12 from the server side.

Also adds `@api_component` wrapper to API methods that were missing it, which caused their API exceptions to always return as 500.